### PR TITLE
statsdameon breaks connection and doesn't send a data

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -136,6 +136,9 @@ func submit() {
 
 	if *debug {
 		for _, line := range bytes.Split(buffer.Bytes(), []byte("\n")) {
+			if len(line) == 0 {
+				continue
+			}
 			log.Printf("DEBUG: %s", line)
 		}
 	}
@@ -282,7 +285,7 @@ func udpListener() {
 	}
 	defer listener.Close()
 
-	message := make([]byte, 0, 512)
+	message := make([]byte, 512)
 	for {
 		_, remaddr, err := listener.ReadFromUDP(message)
 		if err != nil {


### PR DESCRIPTION
I want to use _statsdaemon_ instead original _statsd_.
But I can't managed it to work.
I'm testing it with _netcat_:

```
nc -l -t -p 2003 -v -v
```

I'm running simply with:

```
./statsdaemon
```

After each dial it breaks the connection, and desn't send anything:

```
# netcat output
Listening on any address 2003 (brutus)
Connection from 127.0.0.1:42202
Total received bytes: 0
Total sent bytes: 0
[1]    28110 exit 1     nc -l -t -p 2003 -v -v

# statsdaemon output
2013/08/14 02:34:31 ERROR: dialing 127.0.0.1:2003 - dial tcp 127.0.0.1:2003: connection refused
```
