### PR TITLE
Remove counters that have passed `persist-count-keys`

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -163,6 +163,8 @@ func processCounters(buffer *bytes.Buffer, now int64) int64 {
 	for s, c := range counters {
 		switch {
 		case c <= *persistCountKeys:
+			// consider this purgable
+			delete(counters, s)
 			continue
 		case c < 0:
 			counters[s] -= 1


### PR DESCRIPTION
We consider them to not be interesting anymore.

I have not done thorough testing of this, but I'm creating a pull request for someone else to verify the patch. This is related to #14.
