### PR TITLE
Support lower percentiles

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -210,14 +210,31 @@ func processTimers(buffer *bytes.Buffer, now int64, pctls Percentiles) int64 {
 			for _, pct := range pctls {
 
 				if len(t) > 1 {
+					var abs float64
+					if pct.float >= 0 {
+						abs = pct.float
+					} else {
+						abs = 100 + pct.float
+					}
 					// poor man's math.Round(x):
 					// math.Floor(x + 0.5)
-					indexOfPerc := int(math.Floor(((pct.float / 100.0) * float64(count)) + 0.5))
-					indexOfPerc -= 1  // index offset=0
+					indexOfPerc := int(math.Floor(((abs / 100.0) * float64(count)) + 0.5))
+					if pct.float >= 0 {
+						indexOfPerc -= 1  // index offset=0
+					}
 					maxAtThreshold = t[indexOfPerc]
 				}
 
-				fmt.Fprintf(buffer, "%s.upper_%s %d %d\n", u, pct.str, maxAtThreshold, now)
+				var tmpl string
+				var pctstr string
+				if pct.float >= 0 {
+					tmpl = "%s.upper_%s %d %d\n"
+					pctstr = pct.str
+				} else {
+					tmpl = "%s.lower_%s %d %d\n"
+					pctstr = pct.str[1:]
+				}
+				fmt.Fprintf(buffer, tmpl, u, pctstr, maxAtThreshold, now)
 			}
 
 			var z Uint64Slice

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -131,3 +131,32 @@ func TestUpperPercentile(t *testing.T) {
 	matched := meanRegexp.MatchString(dataForGraphite)
 	assert.Equal(t, matched, true)
 }
+
+func TestLowerPercentile(t *testing.T) {
+	// Some data with expected mean of 20
+	d := []byte("time:0|ms\ntime:1|ms\ntime:2|ms\ntime:3|ms")
+	packets := parseMessage(d)
+
+	for _, s := range packets {
+		timers[s.Bucket] = append(timers[s.Bucket], s.Value.(uint64))
+	}
+
+	var buff bytes.Buffer
+	var num int64
+	num += processTimers(&buff, time.Now().Unix(), Percentiles{
+		&Percentile{
+			-75,
+			"-75",
+		},
+	})
+	assert.Equal(t, num, int64(1))
+	dataForGraphite := buff.String()
+
+	meanRegexp := regexp.MustCompile(`time\.upper_75 1 `)
+	matched := meanRegexp.MatchString(dataForGraphite)
+	assert.Equal(t, matched, false)
+
+	meanRegexp = regexp.MustCompile(`time\.lower_75 1 `)
+	matched = meanRegexp.MatchString(dataForGraphite)
+	assert.Equal(t, matched, true)
+}


### PR DESCRIPTION
Support lower percentiles in accordance with [`statsd`](https://github.com/etsy/statsd). I also found a bug in the current percentile calculation code (correct me if, I'm wrong!). Corrected with a test.

This fixes #18.
