### PR TITLE
Parallelize submission

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -15,9 +15,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
-	"sync"
 )
 
 const (
@@ -171,7 +171,7 @@ func submit(deadline time.Time) error {
 	close(numchan)
 
 	var num int64
-	for n := range(numchan) {
+	for n := range numchan {
 		num += n
 	}
 	if num == 0 {
@@ -261,7 +261,7 @@ func processTimer(buffer *bytes.Buffer, now int64, pctls Percentiles, u string, 
 			// math.Floor(x + 0.5)
 			indexOfPerc := int(math.Floor(((abs / 100.0) * float64(count)) + 0.5))
 			if pct.float >= 0 {
-				indexOfPerc -= 1  // index offset=0
+				indexOfPerc -= 1 // index offset=0
 			}
 			maxAtThreshold = t[indexOfPerc]
 		}

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -235,63 +235,72 @@ func processGauges(buffer *bytes.Buffer, now int64) int64 {
 	return num
 }
 
+func processTimer(buffer *bytes.Buffer, now int64, pctls Percentiles, u string, t Uint64Slice) {
+	sort.Sort(t)
+	min := t[0]
+	max := t[len(t)-1]
+	maxAtThreshold := max
+	count := len(t)
+
+	sum := uint64(0)
+	for _, value := range t {
+		sum += value
+	}
+	mean := float64(sum) / float64(len(t))
+
+	for _, pct := range pctls {
+
+		if len(t) > 1 {
+			var abs float64
+			if pct.float >= 0 {
+				abs = pct.float
+			} else {
+				abs = 100 + pct.float
+			}
+			// poor man's math.Round(x):
+			// math.Floor(x + 0.5)
+			indexOfPerc := int(math.Floor(((abs / 100.0) * float64(count)) + 0.5))
+			if pct.float >= 0 {
+				indexOfPerc -= 1  // index offset=0
+			}
+			maxAtThreshold = t[indexOfPerc]
+		}
+
+		var tmpl string
+		var pctstr string
+		if pct.float >= 0 {
+			tmpl = "%s.upper_%s %d %d\n"
+			pctstr = pct.str
+		} else {
+			tmpl = "%s.lower_%s %d %d\n"
+			pctstr = pct.str[1:]
+		}
+		fmt.Fprintf(buffer, tmpl, u, pctstr, maxAtThreshold, now)
+	}
+
+	var z Uint64Slice
+	timers[u] = z
+
+	fmt.Fprintf(buffer, "%s.mean %f %d\n", u, mean, now)
+	fmt.Fprintf(buffer, "%s.upper %d %d\n", u, max, now)
+	fmt.Fprintf(buffer, "%s.lower %d %d\n", u, min, now)
+	fmt.Fprintf(buffer, "%s.count %d %d\n", u, count, now)
+}
+
 func processTimers(buffer *bytes.Buffer, now int64, pctls Percentiles) int64 {
 	var num int64
+	var wg sync.WaitGroup
 	for u, t := range timers {
 		if len(t) > 0 {
 			num++
-
-			sort.Sort(t)
-			min := t[0]
-			max := t[len(t)-1]
-			maxAtThreshold := max
-			count := len(t)
-
-			sum := uint64(0)
-			for _, value := range t {
-				sum += value
-			}
-			mean := float64(sum) / float64(len(t))
-
-			for _, pct := range pctls {
-
-				if len(t) > 1 {
-					var abs float64
-					if pct.float >= 0 {
-						abs = pct.float
-					} else {
-						abs = 100 + pct.float
-					}
-					// poor man's math.Round(x):
-					// math.Floor(x + 0.5)
-					indexOfPerc := int(math.Floor(((abs / 100.0) * float64(count)) + 0.5))
-					if pct.float >= 0 {
-						indexOfPerc -= 1 // index offset=0
-					}
-					maxAtThreshold = t[indexOfPerc]
-				}
-
-				var tmpl string
-				var pctstr string
-				if pct.float >= 0 {
-					tmpl = "%s.upper_%s %d %d\n"
-					pctstr = pct.str
-				} else {
-					tmpl = "%s.lower_%s %d %d\n"
-					pctstr = pct.str[1:]
-				}
-				fmt.Fprintf(buffer, tmpl, u, pctstr, maxAtThreshold, now)
-			}
-
-			var z Uint64Slice
-			timers[u] = z
-
-			fmt.Fprintf(buffer, "%s.mean %f %d\n", u, mean, now)
-			fmt.Fprintf(buffer, "%s.upper %d %d\n", u, max, now)
-			fmt.Fprintf(buffer, "%s.lower %d %d\n", u, min, now)
-			fmt.Fprintf(buffer, "%s.count %d %d\n", u, count, now)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				processTimer(buffer, now, pctls, u, t)
+			}()
 		}
 	}
+	wg.Wait()
 	return num
 }
 


### PR DESCRIPTION
Make the flush operation execute in parallel.

These optimizations have been mentioned in #23.

Additional comments:
- I'm not sure they are worth incorporating as they might do more harm than good. That said, maybe they can foster a good discussion about possible speed optimizations. I don't know.
- I know good Go practices are to avoid the `sync` package and only use channels. In this case, I thought `sync.WaitGroup` felt like they were making the code more understandable. I might be wrong.
