### PR TITLE
Add in a file path for logging log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,5 @@ Usage of ./statsdaemon:
   -persist-count-keys=60: number of flush-interval's to persist count keys
   -receive-counter="": Metric name for total metrics recevied per interval
   -version=false: print version string
+  -log-to="": Location of log file (uses stdout/stderr if none supplied)
 ```

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -70,7 +70,7 @@ var (
 	receiveCounter   = flag.String("receive-counter", "", "Metric name for total metrics recevied per interval")
 	percentThreshold = Percentiles{}
 	prefix           = flag.String("prefix", "", "Prefix for all stats")
-	logTo            = flag.String("logTo", "", "File location to log")
+	logTo            = flag.String("log-to", "", "Location of log file")
 )
 
 func init() {

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -70,6 +70,7 @@ var (
 	receiveCounter   = flag.String("receive-counter", "", "Metric name for total metrics recevied per interval")
 	percentThreshold = Percentiles{}
 	prefix           = flag.String("prefix", "", "Prefix for all stats")
+	logTo            = flag.String("logTo", "", "File location to log")
 )
 
 func init() {
@@ -402,12 +403,35 @@ func udpListener() {
 	}
 }
 
+func setupLogging() *os.File {
+	if *logTo != "" {
+		f, err := os.OpenFile(*logTo, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+		if err != nil {
+			log.Print("Log file won't open", err)
+			return nil
+		} else {
+			log.SetOutput(f)
+			log.Print("Log path: ", *logTo)
+			return f
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Printf("statsdaemon v%s (built w/%s)\n", VERSION, runtime.Version())
 		return
+	}
+
+	if *logTo != "" {
+		f := setupLogging()
+		if f != nil {
+			defer f.Close()
+		}
 	}
 
 	signalchan = make(chan os.Signal, 1)


### PR DESCRIPTION
Adds in the ability to specify a log file, and just sets `log.SetOutput(...)` to that file handle.