### PR TITLE
Logging tweaks

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -333,7 +333,7 @@ func parseMessage(data []byte) []*Packet {
 		index := bytes.IndexByte(input, ':')
 		if index < 0 {
 			if *debug {
-				log.Printf("ERROR: failed to parse line: %s\n", string(line))
+				log.Printf("ERROR: failed to parse line: %s\n", line)
 			}
 			continue
 		}
@@ -346,7 +346,7 @@ func parseMessage(data []byte) []*Packet {
 		index = bytes.IndexByte(input, '|')
 		if index < 0 {
 			if *debug {
-				log.Printf("ERROR: failed to parse line: %s\n", string(line))
+				log.Printf("ERROR: failed to parse line: %s\n", line)
 			}
 			continue
 		}
@@ -360,7 +360,7 @@ func parseMessage(data []byte) []*Packet {
 			index++
 			if index >= len(input) || input[index] != 's' {
 				if *debug {
-					log.Printf("ERROR: failed to parse line: %s\n", string(line))
+					log.Printf("ERROR: failed to parse line: %s\n", line)
 				}
 				continue
 			}
@@ -380,7 +380,9 @@ func parseMessage(data []byte) []*Packet {
 		if mtypeStr[0] == 'c' {
 			value, err = strconv.ParseInt(string(val), 10, 64)
 			if err != nil {
-				log.Printf("ERROR: failed to ParseInt %s - %s", string(val), err)
+				if *debug {
+					log.Printf("ERROR: failed to ParseInt %s - %s", val, err)
+				}
 				continue
 			}
 		} else if mtypeStr[0] == 'g' {
@@ -400,7 +402,9 @@ func parseMessage(data []byte) []*Packet {
 
 			gaugeValue, err := strconv.ParseUint(stringToParse, 10, 64)
 			if err != nil {
-				log.Printf("ERROR: failed to ParseUint %s - %s", string(val), err)
+				if *debug {
+					log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
+				}
 				continue
 			}
 
@@ -408,7 +412,9 @@ func parseMessage(data []byte) []*Packet {
 		} else {
 			value, err = strconv.ParseUint(string(val), 10, 64)
 			if err != nil {
-				log.Printf("ERROR: failed to ParseUint %s - %s", string(val), err)
+				if *debug {
+					log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
+				}
 				continue
 			}
 		}

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -332,7 +332,7 @@ func parseMessage(data []byte) []*Packet {
 
 		index := bytes.IndexByte(input, ':')
 		if index < 0 {
-			log.Printf("ERROR: failed to parse line: %s\n", line)
+			log.Printf("WARNING: failed to parse line: %s\n", line)
 			continue
 		}
 
@@ -343,7 +343,7 @@ func parseMessage(data []byte) []*Packet {
 
 		index = bytes.IndexByte(input, '|')
 		if index < 0 {
-			log.Printf("ERROR: failed to parse line: %s\n", line)
+			log.Printf("WARNING: failed to parse line: %s\n", line)
 			continue
 		}
 
@@ -355,7 +355,7 @@ func parseMessage(data []byte) []*Packet {
 		if input[index] == 'm' {
 			index++
 			if index >= len(input) || input[index] != 's' {
-				log.Printf("ERROR: failed to parse line: %s\n", line)
+				log.Printf("WARNING: failed to parse line: %s\n", line)
 				continue
 			}
 			mtypeStr = "ms"
@@ -374,7 +374,7 @@ func parseMessage(data []byte) []*Packet {
 		if mtypeStr[0] == 'c' {
 			value, err = strconv.ParseInt(string(val), 10, 64)
 			if err != nil {
-				log.Printf("ERROR: failed to ParseInt %s - %s", val, err)
+				log.Printf("WARNING: failed to ParseInt %s - %s", val, err)
 				continue
 			}
 		} else if mtypeStr[0] == 'g' {
@@ -394,7 +394,7 @@ func parseMessage(data []byte) []*Packet {
 
 			gaugeValue, err := strconv.ParseUint(stringToParse, 10, 64)
 			if err != nil {
-				log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
+				log.Printf("WARNING: failed to ParseUint %s - %s", val, err)
 				continue
 			}
 
@@ -402,7 +402,7 @@ func parseMessage(data []byte) []*Packet {
 		} else {
 			value, err = strconv.ParseUint(string(val), 10, 64)
 			if err != nil {
-				log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
+				log.Printf("WARNING: failed to ParseUint %s - %s", val, err)
 				continue
 			}
 		}

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -332,9 +332,7 @@ func parseMessage(data []byte) []*Packet {
 
 		index := bytes.IndexByte(input, ':')
 		if index < 0 {
-			if *debug {
-				log.Printf("ERROR: failed to parse line: %s\n", line)
-			}
+			log.Printf("ERROR: failed to parse line: %s\n", line)
 			continue
 		}
 
@@ -345,9 +343,7 @@ func parseMessage(data []byte) []*Packet {
 
 		index = bytes.IndexByte(input, '|')
 		if index < 0 {
-			if *debug {
-				log.Printf("ERROR: failed to parse line: %s\n", line)
-			}
+			log.Printf("ERROR: failed to parse line: %s\n", line)
 			continue
 		}
 
@@ -359,9 +355,7 @@ func parseMessage(data []byte) []*Packet {
 		if input[index] == 'm' {
 			index++
 			if index >= len(input) || input[index] != 's' {
-				if *debug {
-					log.Printf("ERROR: failed to parse line: %s\n", line)
-				}
+				log.Printf("ERROR: failed to parse line: %s\n", line)
 				continue
 			}
 			mtypeStr = "ms"
@@ -380,9 +374,7 @@ func parseMessage(data []byte) []*Packet {
 		if mtypeStr[0] == 'c' {
 			value, err = strconv.ParseInt(string(val), 10, 64)
 			if err != nil {
-				if *debug {
-					log.Printf("ERROR: failed to ParseInt %s - %s", val, err)
-				}
+				log.Printf("ERROR: failed to ParseInt %s - %s", val, err)
 				continue
 			}
 		} else if mtypeStr[0] == 'g' {
@@ -402,9 +394,7 @@ func parseMessage(data []byte) []*Packet {
 
 			gaugeValue, err := strconv.ParseUint(stringToParse, 10, 64)
 			if err != nil {
-				if *debug {
-					log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
-				}
+				log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
 				continue
 			}
 
@@ -412,9 +402,7 @@ func parseMessage(data []byte) []*Packet {
 		} else {
 			value, err = strconv.ParseUint(string(val), 10, 64)
 			if err != nil {
-				if *debug {
-					log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
-				}
+				log.Printf("ERROR: failed to ParseUint %s - %s", val, err)
 				continue
 			}
 		}


### PR DESCRIPTION
As suggested in the review of #40 

 - []byte don't need converting to string
 - consistency - only log various parse errors if debug flag is set