### PR TITLE
Purge timers

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -260,10 +260,6 @@ func processGauges(buffer *bytes.Buffer, now int64) int64 {
 func processTimers(buffer *bytes.Buffer, now int64, pctls Percentiles) int64 {
 	var num int64
 	for u, t := range timers {
-		if len(t) == 0 {
-			continue
-		}
-
 		num++
 
 		sort.Sort(t)


### PR DESCRIPTION
Had a look at #14 and I think this simple fix ensures that empty map entries for timers aren't persisted
