### PR TITLE
Ability to configure max udp packet size

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Command Line Options
 ```
 Usage of ./statsdaemon:
   -address=":8125": UDP service address
+  -max-udp-packet-size=512: Maximum udp packet size
   -debug=false: print statistics sent to graphite
   -flush-interval=10: Flush interval (seconds)
   -graphite="127.0.0.1:2003": Graphite service address (or - to disable)

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -67,6 +67,7 @@ func (a *Percentiles) String() string {
 
 var (
 	serviceAddress   = flag.String("address", ":8125", "UDP service address")
+	maxUdpPacketSize = flag.Int64("max-udp-packet-size", 512, "Maximum UDP packet size")
 	graphiteAddress  = flag.String("graphite", "127.0.0.1:2003", "Graphite service address (or - to disable)")
 	flushInterval    = flag.Int64("flush-interval", 10, "Flush interval (seconds)")
 	debug            = flag.Bool("debug", false, "print statistics sent to graphite")
@@ -464,7 +465,7 @@ func udpListener() {
 	}
 	defer listener.Close()
 
-	message := make([]byte, MAX_UDP_PACKET_SIZE)
+	message := make([]byte, *maxUdpPacketSize)
 	for {
 		n, remaddr, err := listener.ReadFromUDP(message)
 		if err != nil {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.6-alpha"
+const VERSION = "0.7-alpha"


### PR DESCRIPTION
Added ability to configure maximum udp packe size to prevent index out of range errors when receiving packets larger than the constant size of 512.