### PR TITLE
reject metric lines that end in : or |, instead of panicing

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -350,7 +350,7 @@ func parseMessage(data []byte) []*Packet {
 		input = line
 
 		index := bytes.IndexByte(input, ':')
-		if index < 0 {
+		if index < 0 || index == len(input) - 1 {
 			if *debug {
 				log.Printf("ERROR: failed to parse line: %s\n", string(line))
 			}
@@ -363,7 +363,7 @@ func parseMessage(data []byte) []*Packet {
 		input = input[index:]
 
 		index = bytes.IndexByte(input, '|')
-		if index < 0 {
+		if index < 0 || index == len(input) - 1 {
 			if *debug {
 				log.Printf("ERROR: failed to parse line: %s\n", string(line))
 			}

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -180,6 +180,12 @@ func TestPacketParseMisc(t *testing.T) {
 	d = []byte("deploys.test.myservice4:100|t")
 	packets = parseMessage(d)
 	packetHandler(packets[0])
+
+	d = []byte("up-to-colon:")
+	packets = parseMessage(d)
+
+	d = []byte("up-to-pipe:1|")
+	packets = parseMessage(d)
 }
 
 func TestReceiveCounterPacketHandling(t *testing.T) {


### PR DESCRIPTION
crash noticed by @gevorg15 for #53