### PR TITLE
add a TCP listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ Usage of ./statsdaemon:
   -postfix="": Postfix for all stats
   -delete-gauges=true: don't send values to graphite for inactive gauges, as opposed to sending the previous value
   -receive-counter="": Metric name for total metrics received per interval
+  -tcpaddr="": TCP service address, if set
   -version=false: print version string
 ```

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	MAX_UNPROCESSED_PACKETS = 1000
-	READ_SIZE               = 4096
+	TCP_READ_SIZE           = 4096
 )
 
 var signalchan chan os.Signal
@@ -395,7 +395,12 @@ func (mp *MsgParser) Next() (*Packet, bool) {
 		}
 
 		idx := len(buf)
-		end := idx + READ_SIZE
+		end := idx
+		if mp.partialReads {
+			end += TCP_READ_SIZE
+		} else {
+			end += int(*maxUdpPacketSize)
+		}
 		if cap(buf) >= end {
 			buf = buf[:end]
 		} else {


### PR DESCRIPTION
Because individual sends via TCP can end up split across packet
boundaries, the parsing code had to be reworked to handle that case.
It now takes io.ReadCloser rather than []byte.

It is used this way in the UDP case as well.