### PR TITLE
Add a flag to match StatsD's config.deleteGauges knob.

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -75,6 +75,7 @@ var (
 	receiveCounter   = flag.String("receive-counter", "", "Metric name for total metrics received per interval")
 	percentThreshold = Percentiles{}
 	prefix           = flag.String("prefix", "", "Prefix for all stats")
+	deleteGauges     = flag.Bool("delete-gauges", true, "don't send unchanged gauge values on flush")
 )
 
 func init() {
@@ -256,7 +257,7 @@ func processGauges(buffer *bytes.Buffer, now int64) int64 {
 	for g, c := range gauges {
 		lastValue, ok := trackedGauges[g]
 
-		if ok && c == lastValue {
+		if ok && *deleteGauges && c == lastValue {
 			continue
 		}
 		fmt.Fprintf(buffer, "%s %d %d\n", g, c, now)


### PR DESCRIPTION
I ran into a case where I wanted to send a counter value (like a packet counter from a network interface) and wanted gauge('some.network.metric', value) to re-send the last value on flush.  This pull request maintains the default behavior of statsdaemon, but adds a flag so that you can make statsdaemon re-send the previous gauge values on flush.

Thanks!