### PR TITLE
remove regexp for performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 install:
   - go get github.com/bmizerany/assert
 script:

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -67,17 +66,25 @@ func (a *Percentiles) String() string {
 	return fmt.Sprintf("%v", *a)
 }
 
-var (
-	sanitizeFilter1 = regexp.MustCompile(`\s+`)
-	sanitizeFilter2 = regexp.MustCompile(`\/`)
-	sanitizeFilter3 = regexp.MustCompile(`[^a-zA-Z_\-0-9\.]`)
-)
-
 func sanitizeBucket(bucket string) string {
-	bucket = sanitizeFilter1.ReplaceAllString(bucket, "_")
-	bucket = sanitizeFilter2.ReplaceAllString(bucket, "-")
-	bucket = sanitizeFilter3.ReplaceAllString(bucket, "")
-	return bucket
+	b := make([]byte, len(bucket))
+	var bl int
+
+	for i := 0; i < len(bucket); i++ {
+		c := bucket[i]
+		switch {
+		case (c >= byte('a') && c <= byte('z')) || (c >= byte('A') && c <= byte('Z')) || (c >= byte('0') && c <= byte('9')) || c == byte('-') || c == byte('.') || c == byte('_'):
+			b[bl] = c
+			bl++
+		case c == byte(' '):
+			b[bl] = byte('_')
+			bl++
+		case c == byte('/'):
+			b[bl] = byte('-')
+			bl++
+		}
+	}
+	return string(b[:bl])
 }
 
 var (


### PR DESCRIPTION
While the regex version reads easier, the performance difference is very noticeable even for these easy replacements.

```
master:
BenchmarkManyDifferentSensors	       1	1928148881 ns/op
BenchmarkOneBigTimer	       1	1845274355 ns/op
BenchmarkLotsOfTimers	       1	1902944310 ns/op
BenchmarkParseLine	  300000	      5568 ns/op

non_regex:
BenchmarkManyDifferentSensors	       1	1838807819 ns/op
BenchmarkOneBigTimer	       1	1769153610 ns/op
BenchmarkLotsOfTimers	       1	1853729588 ns/op
BenchmarkParseLine	 1000000	      1131 ns/op
```