### PR TITLE
fix some cross-compile issues from linux, touch up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,33 @@ Supports
 * Gauges (including relative operations)
 * Sets
 
+Note: Only integers are supported for metric values.
+
 [![Build Status](https://secure.travis-ci.org/bitly/statsdaemon.png)](http://travis-ci.org/bitly/statsdaemon)
 
 Installing
 ==========
 
-```bash
-go get github.com/bitly/statsdaemon
+### Binary Releases
+Pre-built binaries for darwin and linux.
+
+### Current Stable Release: `v0.7`
+* [statsdaemon-0.7.darwin-amd64.go1.4.2.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7/statsdaemon-0.7.darwin-amd64.go1.4.2.tar.gz)
+* [statsdaemon-0.7.linux-amd64.go1.4.2.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7/statsdaemon-0.7.linux-amd64.go1.4.2.tar.gz)
+
+### Older Releases
+* [statsdaemon-0.6-alpha.darwin-amd64.go1.3.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.6-alpha/statsdaemon-0.6-alpha.darwin-amd64.go1.3.tar.gz)
+* [statsdaemon-0.6-alpha.linux-amd64.go1.3.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.6-alpha/statsdaemon-0.6-alpha.linux-amd64.go1.3.tar.gz)
+* [statsdaemon-0.5.2-alpha.linux-amd64.go1.1.1.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.5.2-alpha/statsdaemon-0.5.2-alpha.linux-amd64.go1.1.1.tar.gz)
+
+### Building from Source
 ```
+git clone https://github.com/bitly/statsdaemon
+cd statsdaemon
+go get github.com/bmizerany/assert #for tests
+go build
+```
+
 
 Command Line Options
 ====================
@@ -26,15 +45,15 @@ Command Line Options
 ```
 Usage of ./statsdaemon:
   -address=":8125": UDP service address
-  -max-udp-packet-size=1472: Maximum udp packet size
   -debug=false: print statistics sent to graphite
+  -delete-gauges=true: don't send values to graphite for inactive gauges, as opposed to sending the previous value
   -flush-interval=10: Flush interval (seconds)
   -graphite="127.0.0.1:2003": Graphite service address (or - to disable)
+  -max-udp-packet-size=1472: Maximum UDP packet size
   -percent-threshold=[]: percentile calculation for timers (0-100, may be given multiple times)
   -persist-count-keys=60: number of flush-intervals to persist count keys
-  -prefix="": Prefix for all stats
   -postfix="": Postfix for all stats
-  -delete-gauges=true: don't send values to graphite for inactive gauges, as opposed to sending the previous value
+  -prefix="": Prefix for all stats
   -receive-counter="": Metric name for total metrics received per interval
   -tcpaddr="": TCP service address, if set
   -version=false: print version string

--- a/dist.sh
+++ b/dist.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
 # build binary distributions for linux/amd64 and darwin/amd64
-set -e 
+set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "working dir $DIR"
 mkdir -p $DIR/dist
 
-os=$(go env GOOS)
 arch=$(go env GOARCH)
 version=$(cat $DIR/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
 goversion=$(go version | awk '{print $3}')
@@ -17,7 +16,7 @@ echo "... running tests"
 
 for os in linux darwin; do
     echo "... building v$version for $os/$arch"
-    BUILD=$(mktemp -d -t statsdaemon)
+    BUILD=$(mktemp -d -t statsdaemon.XXXXXXXX)
     TARGET="statsdaemon-$version.$os-$arch.$goversion"
     GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/statsdaemon || exit 1
     pushd $BUILD

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7-alpha"
+const VERSION = "0.7"


### PR DESCRIPTION
Updated the README with some clearer instructions for grabbing releases vs dev and fixed mktemp in dist.sh. The linux version does not auto append random data to the dir so it will bomb.