### PR TITLE
switch metrics to float64

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -36,14 +36,14 @@ type Packet struct {
 type GaugeData struct {
 	Relative bool
 	Negative bool
-	Value    uint64
+	Value    float64
 }
 
-type Uint64Slice []uint64
+type Float64Slice []float64
 
-func (s Uint64Slice) Len() int           { return len(s) }
-func (s Uint64Slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s Uint64Slice) Less(i, j int) bool { return s[i] < s[j] }
+func (s Float64Slice) Len() int           { return len(s) }
+func (s Float64Slice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s Float64Slice) Less(i, j int) bool { return s[i] < s[j] }
 
 type Percentiles []*Percentile
 type Percentile struct {
@@ -110,10 +110,10 @@ func init() {
 
 var (
 	In              = make(chan *Packet, MAX_UNPROCESSED_PACKETS)
-	counters        = make(map[string]int64)
-	gauges          = make(map[string]uint64)
-	lastGaugeValue  = make(map[string]uint64)
-	timers          = make(map[string]Uint64Slice)
+	counters        = make(map[string]float64)
+	gauges          = make(map[string]float64)
+	lastGaugeValue  = make(map[string]float64)
+	timers          = make(map[string]Float64Slice)
 	countInactivity = make(map[string]int64)
 	sets            = make(map[string][]string)
 )
@@ -152,10 +152,10 @@ func packetHandler(s *Packet) {
 	case "ms":
 		_, ok := timers[s.Bucket]
 		if !ok {
-			var t Uint64Slice
+			var t Float64Slice
 			timers[s.Bucket] = t
 		}
-		timers[s.Bucket] = append(timers[s.Bucket], s.Value.(uint64))
+		timers[s.Bucket] = append(timers[s.Bucket], s.Value.(float64))
 	case "g":
 		gaugeValue, _ := gauges[s.Bucket]
 
@@ -170,8 +170,8 @@ func packetHandler(s *Packet) {
 				}
 			} else {
 				// watch out for overflows
-				if gaugeData.Value > (math.MaxUint64 - gaugeValue) {
-					gaugeValue = math.MaxUint64
+				if gaugeData.Value > (math.MaxFloat64 - gaugeValue) {
+					gaugeValue = math.MaxFloat64
 				} else {
 					gaugeValue += gaugeData.Value
 				}
@@ -186,7 +186,7 @@ func packetHandler(s *Packet) {
 		if !ok {
 			counters[s.Bucket] = 0
 		}
-		counters[s.Bucket] += int64(float64(s.Value.(int64)) * float64(1/s.Sampling))
+		counters[s.Bucket] += float64(s.Value.(int64)) * float64(1/s.Sampling)
 	case "s":
 		_, ok := sets[s.Bucket]
 		if !ok {
@@ -257,14 +257,14 @@ func processCounters(buffer *bytes.Buffer, now int64) int64 {
 	var num int64
 	// continue sending zeros for counters for a short period of time even if we have no new data
 	for bucket, value := range counters {
-		fmt.Fprintf(buffer, "%s %d %d\n", bucket, value, now)
+		fmt.Fprintf(buffer, "%s %s %d\n", bucket, strconv.FormatFloat(value, 'f', -1, 64), now)
 		delete(counters, bucket)
 		countInactivity[bucket] = 0
 		num++
 	}
 	for bucket, purgeCount := range countInactivity {
 		if purgeCount > 0 {
-			fmt.Fprintf(buffer, "%s %d %d\n", bucket, 0, now)
+			fmt.Fprintf(buffer, "%s 0 %d\n", bucket, now)
 			num++
 		}
 		countInactivity[bucket] += 1
@@ -289,12 +289,12 @@ func processGauges(buffer *bytes.Buffer, now int64) int64 {
 
 		switch {
 		case hasChanged:
-			fmt.Fprintf(buffer, "%s %d %d\n", bucket, currentValue, now)
+			fmt.Fprintf(buffer, "%s %s %d\n", bucket, strconv.FormatFloat(currentValue, 'f', -1, 64), now)
 			lastGaugeValue[bucket] = currentValue
 			gauges[bucket] = math.MaxUint64
 			num++
 		case hasLastValue && !hasChanged && !*deleteGauges:
-			fmt.Fprintf(buffer, "%s %d %d\n", bucket, lastValue, now)
+			fmt.Fprintf(buffer, "%s %s %d\n", bucket, strconv.FormatFloat(lastValue, 'f', -1, 64), now)
 			num++
 		default:
 			continue
@@ -330,11 +330,11 @@ func processTimers(buffer *bytes.Buffer, now int64, pctls Percentiles) int64 {
 		maxAtThreshold := max
 		count := len(timer)
 
-		sum := uint64(0)
+		sum := float64(0)
 		for _, value := range timer {
 			sum += value
 		}
-		mean := float64(sum) / float64(len(timer))
+		mean := sum / float64(len(timer))
 
 		for _, pct := range pctls {
 			if len(timer) > 1 {
@@ -356,18 +356,23 @@ func processTimers(buffer *bytes.Buffer, now int64, pctls Percentiles) int64 {
 			var tmpl string
 			var pctstr string
 			if pct.float >= 0 {
-				tmpl = "%s.upper_%s%s %d %d\n"
+				tmpl = "%s.upper_%s%s %s %d\n"
 				pctstr = pct.str
 			} else {
-				tmpl = "%s.lower_%s%s %d %d\n"
+				tmpl = "%s.lower_%s%s %s %d\n"
 				pctstr = pct.str[1:]
 			}
-			fmt.Fprintf(buffer, tmpl, bucketWithoutPostfix, pctstr, *postfix, maxAtThreshold, now)
+			threshold_s := strconv.FormatFloat(maxAtThreshold, 'f', -1, 64)
+			fmt.Fprintf(buffer, tmpl, bucketWithoutPostfix, pctstr, *postfix, threshold_s, now)
 		}
 
-		fmt.Fprintf(buffer, "%s.mean%s %f %d\n", bucketWithoutPostfix, *postfix, mean, now)
-		fmt.Fprintf(buffer, "%s.upper%s %d %d\n", bucketWithoutPostfix, *postfix, max, now)
-		fmt.Fprintf(buffer, "%s.lower%s %d %d\n", bucketWithoutPostfix, *postfix, min, now)
+		mean_s := strconv.FormatFloat(mean, 'f', -1, 64)
+		max_s := strconv.FormatFloat(max, 'f', -1, 64)
+		min_s := strconv.FormatFloat(min, 'f', -1, 64)
+
+		fmt.Fprintf(buffer, "%s.mean%s %s %d\n", bucketWithoutPostfix, *postfix, mean_s, now)
+		fmt.Fprintf(buffer, "%s.upper%s %s %d\n", bucketWithoutPostfix, *postfix, max_s, now)
+		fmt.Fprintf(buffer, "%s.lower%s %s %d\n", bucketWithoutPostfix, *postfix, min_s, now)
 		fmt.Fprintf(buffer, "%s.count%s %d %d\n", bucketWithoutPostfix, *postfix, count, now)
 
 		delete(timers, bucket)
@@ -505,7 +510,7 @@ func parseLine(line []byte) *Packet {
 
 	switch typeCode {
 	case "c":
-		value, err = strconv.ParseInt(string(val), 10, 64)
+		value, err = strconv.ParseFloat(string(val), 64)
 		if err != nil {
 			log.Printf("ERROR: failed to ParseInt %s - %s", string(val), err)
 			return nil
@@ -529,19 +534,19 @@ func parseLine(line []byte) *Packet {
 			s = string(val)
 		}
 
-		value, err = strconv.ParseUint(s, 10, 64)
+		value, err = strconv.ParseFloat(s, 64)
 		if err != nil {
 			log.Printf("ERROR: failed to ParseUint %s - %s", string(val), err)
 			return nil
 		}
 
-		value = GaugeData{rel, neg, value.(uint64)}
+		value = GaugeData{rel, neg, value.(float64)}
 	case "s":
 		value = string(val)
 	case "ms":
-		value, err = strconv.ParseUint(string(val), 10, 64)
+		value, err = strconv.ParseFloat(string(val), 64)
 		if err != nil {
-			log.Printf("ERROR: failed to ParseUint %s - %s", string(val), err)
+			log.Printf("ERROR: failed to ParseFloat %s - %s", string(val), err)
 			return nil
 		}
 	default:

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -54,6 +54,15 @@ func TestParseLineGauge(t *testing.T) {
 	assert.Equal(t, GaugeData{false, false, 18446744073709551606}, packet.Value)
 	assert.Equal(t, "g", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
+
+	// float values
+	d = []byte("gaugor:3.3333|g")
+	packet = parseLine(d)
+	assert.NotEqual(t, packet, nil)
+	assert.Equal(t, "gaugor", packet.Bucket)
+	assert.Equal(t, GaugeData{false, false, 3.3333}, packet.Value)
+	assert.Equal(t, "g", packet.Modifier)
+	assert.Equal(t, float32(1), packet.Sampling)
 }
 
 func TestParseLineCount(t *testing.T) {
@@ -61,7 +70,7 @@ func TestParseLineCount(t *testing.T) {
 	packet := parseLine(d)
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, "gorets", packet.Bucket)
-	assert.Equal(t, int64(2), packet.Value.(int64))
+	assert.Equal(t, float64(2), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(0.1), packet.Sampling)
 
@@ -69,7 +78,7 @@ func TestParseLineCount(t *testing.T) {
 	packet = parseLine(d)
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, "gorets", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
@@ -77,7 +86,15 @@ func TestParseLineCount(t *testing.T) {
 	packet = parseLine(d)
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, "gorets", packet.Bucket)
-	assert.Equal(t, int64(-4), packet.Value.(int64))
+	assert.Equal(t, float64(-4), packet.Value.(float64))
+	assert.Equal(t, "c", packet.Modifier)
+	assert.Equal(t, float32(1), packet.Sampling)
+
+	d = []byte("gorets:1.25|c")
+	packet = parseLine(d)
+	assert.NotEqual(t, packet, nil)
+	assert.Equal(t, "gorets", packet.Bucket)
+	assert.Equal(t, 1.25, packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 }
@@ -87,7 +104,7 @@ func TestParseLineTimer(t *testing.T) {
 	packet := parseLine(d)
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, "glork", packet.Bucket)
-	assert.Equal(t, uint64(320), packet.Value.(uint64))
+	assert.Equal(t, float64(320), packet.Value.(float64))
 	assert.Equal(t, "ms", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
@@ -95,9 +112,17 @@ func TestParseLineTimer(t *testing.T) {
 	packet = parseLine(d)
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, "glork", packet.Bucket)
-	assert.Equal(t, uint64(320), packet.Value.(uint64))
+	assert.Equal(t, float64(320), packet.Value.(float64))
 	assert.Equal(t, "ms", packet.Modifier)
 	assert.Equal(t, float32(0.1), packet.Sampling)
+
+	d = []byte("glork:3.7211|ms")
+	packet = parseLine(d)
+	assert.NotEqual(t, packet, nil)
+	assert.Equal(t, "glork", packet.Bucket)
+	assert.Equal(t, float64(3.7211), packet.Value.(float64))
+	assert.Equal(t, "ms", packet.Modifier)
+	assert.Equal(t, float32(1), packet.Sampling)
 }
 
 func TestParseLineSet(t *testing.T) {
@@ -115,28 +140,28 @@ func TestParseLineMisc(t *testing.T) {
 	packet := parseLine(d)
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, "a.key.with-0.dash", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
 	d = []byte("a.key.with 0.space:4|c")
 	packet = parseLine(d)
 	assert.Equal(t, "a.key.with_0.space", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
 	d = []byte("a.key.with/0.slash:4|c")
 	packet = parseLine(d)
 	assert.Equal(t, "a.key.with-0.slash", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
 	d = []byte("a.key.with@#*&%$^_0.garbage:4|c")
 	packet = parseLine(d)
 	assert.Equal(t, "a.key.with_0.garbage", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
@@ -144,7 +169,7 @@ func TestParseLineMisc(t *testing.T) {
 	d = []byte("prefix:4|c")
 	packet = parseLine(d)
 	assert.Equal(t, "test.prefix", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 	flag.Set("prefix", "")
@@ -153,7 +178,7 @@ func TestParseLineMisc(t *testing.T) {
 	d = []byte("postfix:4|c")
 	packet = parseLine(d)
 	assert.Equal(t, "postfix.test", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 	flag.Set("postfix", "")
@@ -163,7 +188,7 @@ func TestParseLineMisc(t *testing.T) {
 	packet, more := parser.Next()
 	assert.Equal(t, more, true)
 	assert.Equal(t, "a.key.with-0.dash", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
@@ -267,7 +292,7 @@ func TestMultiLine(t *testing.T) {
 	assert.NotEqual(t, packet, nil)
 	assert.Equal(t, more, true)
 	assert.Equal(t, "a.key.with-0.dash", packet.Bucket)
-	assert.Equal(t, int64(4), packet.Value.(int64))
+	assert.Equal(t, float64(4), packet.Value.(float64))
 	assert.Equal(t, "c", packet.Modifier)
 	assert.Equal(t, float32(1), packet.Sampling)
 
@@ -281,7 +306,7 @@ func TestMultiLine(t *testing.T) {
 }
 
 func TestPacketHandlerReceiveCounter(t *testing.T) {
-	counters = make(map[string]int64)
+	counters = make(map[string]float64)
 	*receiveCounter = "countme"
 
 	p := &Packet{
@@ -291,14 +316,14 @@ func TestPacketHandlerReceiveCounter(t *testing.T) {
 		Sampling: float32(1),
 	}
 	packetHandler(p)
-	assert.Equal(t, counters["countme"], int64(1))
+	assert.Equal(t, counters["countme"], float64(1))
 
 	packetHandler(p)
-	assert.Equal(t, counters["countme"], int64(2))
+	assert.Equal(t, counters["countme"], float64(2))
 }
 
 func TestPacketHandlerCount(t *testing.T) {
-	counters = make(map[string]int64)
+	counters = make(map[string]float64)
 
 	p := &Packet{
 		Bucket:   "gorets",
@@ -307,23 +332,23 @@ func TestPacketHandlerCount(t *testing.T) {
 		Sampling: float32(1),
 	}
 	packetHandler(p)
-	assert.Equal(t, counters["gorets"], int64(100))
+	assert.Equal(t, counters["gorets"], float64(100))
 
 	p.Value = int64(3)
 	packetHandler(p)
-	assert.Equal(t, counters["gorets"], int64(103))
+	assert.Equal(t, counters["gorets"], float64(103))
 
 	p.Value = int64(-4)
 	packetHandler(p)
-	assert.Equal(t, counters["gorets"], int64(99))
+	assert.Equal(t, counters["gorets"], float64(99))
 
 	p.Value = int64(-100)
 	packetHandler(p)
-	assert.Equal(t, counters["gorets"], int64(-1))
+	assert.Equal(t, counters["gorets"], float64(-1))
 }
 
 func TestPacketHandlerGauge(t *testing.T) {
-	gauges = make(map[string]uint64)
+	gauges = make(map[string]float64)
 
 	p := &Packet{
 		Bucket:   "gaugor",
@@ -332,50 +357,50 @@ func TestPacketHandlerGauge(t *testing.T) {
 		Sampling: float32(1),
 	}
 	packetHandler(p)
-	assert.Equal(t, gauges["gaugor"], uint64(333))
+	assert.Equal(t, gauges["gaugor"], float64(333))
 
 	// -10
 	p.Value = GaugeData{true, true, 10}
 	packetHandler(p)
-	assert.Equal(t, gauges["gaugor"], uint64(323))
+	assert.Equal(t, gauges["gaugor"], float64(323))
 
 	// +4
 	p.Value = GaugeData{true, false, 4}
 	packetHandler(p)
-	assert.Equal(t, gauges["gaugor"], uint64(327))
+	assert.Equal(t, gauges["gaugor"], float64(327))
 
 	// <0 overflow
 	p.Value = GaugeData{false, false, 10}
 	packetHandler(p)
 	p.Value = GaugeData{true, true, 20}
 	packetHandler(p)
-	assert.Equal(t, gauges["gaugor"], uint64(0))
+	assert.Equal(t, gauges["gaugor"], float64(0))
 
 	// >2^64 overflow
-	p.Value = GaugeData{false, false, uint64(math.MaxUint64 - 10)}
+	p.Value = GaugeData{false, false, float64(math.MaxFloat64 - 10)}
 	packetHandler(p)
 	p.Value = GaugeData{true, false, 20}
 	packetHandler(p)
-	assert.Equal(t, gauges["gaugor"], uint64(math.MaxUint64))
+	assert.Equal(t, gauges["gaugor"], float64(math.MaxFloat64))
 }
 
 func TestPacketHandlerTimer(t *testing.T) {
-	timers = make(map[string]Uint64Slice)
+	timers = make(map[string]Float64Slice)
 
 	p := &Packet{
 		Bucket:   "glork",
-		Value:    uint64(320),
+		Value:    float64(320),
 		Modifier: "ms",
 		Sampling: float32(1),
 	}
 	packetHandler(p)
 	assert.Equal(t, len(timers["glork"]), 1)
-	assert.Equal(t, timers["glork"][0], uint64(320))
+	assert.Equal(t, timers["glork"][0], float64(320))
 
-	p.Value = uint64(100)
+	p.Value = float64(100)
 	packetHandler(p)
 	assert.Equal(t, len(timers["glork"]), 2)
-	assert.Equal(t, timers["glork"][1], uint64(100))
+	assert.Equal(t, timers["glork"][1], float64(100))
 }
 
 func TestPacketHandlerSet(t *testing.T) {
@@ -400,11 +425,11 @@ func TestPacketHandlerSet(t *testing.T) {
 func TestProcessCounters(t *testing.T) {
 
 	*persistCountKeys = int64(10)
-	counters = make(map[string]int64)
+	counters = make(map[string]float64)
 	var buffer bytes.Buffer
 	now := int64(1418052649)
 
-	counters["gorets"] = int64(123)
+	counters["gorets"] = float64(123)
 
 	num := processCounters(&buffer, now)
 	assert.Equal(t, num, int64(1))
@@ -424,8 +449,8 @@ func TestProcessCounters(t *testing.T) {
 
 func TestProcessTimers(t *testing.T) {
 	// Some data with expected mean of 20
-	timers = make(map[string]Uint64Slice)
-	timers["response_time"] = []uint64{0, 30, 30}
+	timers = make(map[string]Float64Slice)
+	timers["response_time"] = []float64{0, 30, 30}
 
 	now := int64(1418052649)
 
@@ -435,7 +460,7 @@ func TestProcessTimers(t *testing.T) {
 	lines := bytes.Split(buffer.Bytes(), []byte("\n"))
 
 	assert.Equal(t, num, int64(1))
-	assert.Equal(t, string(lines[0]), "response_time.mean 20.000000 1418052649")
+	assert.Equal(t, string(lines[0]), "response_time.mean 20 1418052649")
 	assert.Equal(t, string(lines[1]), "response_time.upper 30 1418052649")
 	assert.Equal(t, string(lines[2]), "response_time.lower 0 1418052649")
 	assert.Equal(t, string(lines[3]), "response_time.count 3 1418052649")
@@ -447,7 +472,7 @@ func TestProcessTimers(t *testing.T) {
 func TestProcessGauges(t *testing.T) {
 	// Some data with expected mean of 20
 	flag.Set("delete-gauges", "false")
-	gauges = make(map[string]uint64)
+	gauges = make(map[string]float64)
 	gauges["gaugor"] = math.MaxUint64
 
 	now := int64(1418052649)
@@ -471,7 +496,7 @@ func TestProcessGauges(t *testing.T) {
 func TestProcessDeleteGauges(t *testing.T) {
 	// Some data with expected mean of 20
 	flag.Set("delete-gauges", "true")
-	gauges = make(map[string]uint64)
+	gauges = make(map[string]float64)
 	gauges["gaugordelete"] = math.MaxUint64
 
 	now := int64(1418052649)
@@ -519,8 +544,8 @@ func TestProcessSets(t *testing.T) {
 
 func TestProcessTimersUpperPercentile(t *testing.T) {
 	// Some data with expected 75% of 2
-	timers = make(map[string]Uint64Slice)
-	timers["response_time"] = []uint64{0, 1, 2, 3}
+	timers = make(map[string]Float64Slice)
+	timers["response_time"] = []float64{0, 1, 2, 3}
 
 	now := int64(1418052649)
 
@@ -541,8 +566,8 @@ func TestProcessTimersUpperPercentile(t *testing.T) {
 func TestProcessTimersUpperPercentilePostfix(t *testing.T) {
 	flag.Set("postfix", ".test")
 	// Some data with expected 75% of 2
-	timers = make(map[string]Uint64Slice)
-	timers["postfix_response_time.test"] = []uint64{0, 1, 2, 3}
+	timers = make(map[string]Float64Slice)
+	timers["postfix_response_time.test"] = []float64{0, 1, 2, 3}
 
 	now := int64(1418052649)
 
@@ -562,8 +587,8 @@ func TestProcessTimersUpperPercentilePostfix(t *testing.T) {
 }
 
 func TestProcessTimesLowerPercentile(t *testing.T) {
-	timers = make(map[string]Uint64Slice)
-	timers["time"] = []uint64{0, 1, 2, 3}
+	timers = make(map[string]Float64Slice)
+	timers["time"] = []float64{0, 1, 2, 3}
 
 	now := int64(1418052649)
 
@@ -613,7 +638,7 @@ func TestMultipleUDPSends(t *testing.T) {
 	select {
 	case pack := <-ch:
 		assert.Equal(t, "deploys.test.myservice", pack.Bucket)
-		assert.Equal(t, int64(2), pack.Value.(int64))
+		assert.Equal(t, float64(2), pack.Value.(float64))
 		assert.Equal(t, "c", pack.Modifier)
 		assert.Equal(t, float32(1), pack.Sampling)
 	case <-time.After(50 * time.Millisecond):
@@ -623,7 +648,7 @@ func TestMultipleUDPSends(t *testing.T) {
 	select {
 	case pack := <-ch:
 		assert.Equal(t, "deploys.test.myservice", pack.Bucket)
-		assert.Equal(t, int64(1), pack.Value.(int64))
+		assert.Equal(t, float64(1), pack.Value.(float64))
 		assert.Equal(t, "c", pack.Modifier)
 		assert.Equal(t, float32(1), pack.Sampling)
 	case <-time.After(50 * time.Millisecond):
@@ -639,7 +664,7 @@ func BenchmarkManyDifferentSensors(t *testing.B) {
 	for i := 0; i < 1000; i++ {
 		bucket := "response_time" + strconv.Itoa(i)
 		for i := 0; i < 10000; i++ {
-			a := uint64(r.Uint32() % 1000)
+			a := float64(r.Uint32() % 1000)
 			timers[bucket] = append(timers[bucket], a)
 		}
 	}
@@ -647,7 +672,7 @@ func BenchmarkManyDifferentSensors(t *testing.B) {
 	for i := 0; i < 1000; i++ {
 		bucket := "count" + strconv.Itoa(i)
 		for i := 0; i < 10000; i++ {
-			a := int64(r.Uint32() % 1000)
+			a := float64(r.Uint32() % 1000)
 			counters[bucket] = a
 		}
 	}
@@ -655,7 +680,7 @@ func BenchmarkManyDifferentSensors(t *testing.B) {
 	for i := 0; i < 1000; i++ {
 		bucket := "gauge" + strconv.Itoa(i)
 		for i := 0; i < 10000; i++ {
-			a := uint64(r.Uint32() % 1000)
+			a := float64(r.Uint32() % 1000)
 			gauges[bucket] = a
 		}
 	}
@@ -672,7 +697,7 @@ func BenchmarkOneBigTimer(t *testing.B) {
 	r := rand.New(rand.NewSource(438))
 	bucket := "response_time"
 	for i := 0; i < 10000000; i++ {
-		a := uint64(r.Uint32() % 1000)
+		a := float64(r.Uint32() % 1000)
 		timers[bucket] = append(timers[bucket], a)
 	}
 
@@ -686,7 +711,7 @@ func BenchmarkLotsOfTimers(t *testing.B) {
 	for i := 0; i < 1000; i++ {
 		bucket := "response_time" + strconv.Itoa(i)
 		for i := 0; i < 10000; i++ {
-			a := uint64(r.Uint32() % 1000)
+			a := float64(r.Uint32() % 1000)
 			timers[bucket] = append(timers[bucket], a)
 		}
 	}


### PR DESCRIPTION
I was having trouble with [go-statsd-client](https://github.com/cactus/go-statsd-client/blob/dc93b8587d799a204e96175505fff9678a8ec3e1/statsd/main.go#L138) and realized the issue was server-side: timers are being parsed as uint64s, but decimal points are allowed. [evidence](https://github.com/etsy/statsd/blob/69228a9f5ed57d249c15aa8e6294239a73336198/stats.js#L259)