### PR TITLE
ensure listener does not close on parse errors

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -569,11 +569,9 @@ func parseTo(conn io.ReadCloser, partialReads bool, out chan<- *Packet) {
 	parser := NewParser(conn, partialReads)
 	for {
 		p, more := parser.Next()
-		if p == nil {
-			break
+		if p != nil {
+			out <- p
 		}
-
-		out <- p
 
 		if !more {
 			break

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -604,6 +604,8 @@ func TestMultipleUDPSends(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, len("deploys.test.myservice:2|c"), n)
 
+	n, err = conn.Write([]byte("deploys.test.my:service:2|c"))
+
 	n, err = conn.Write([]byte("deploys.test.myservice:1|c"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, len("deploys.test.myservice:1|c"), n)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7"
+const VERSION = "0.8-alpha"


### PR DESCRIPTION
Parse errors would return nil and cause the listener to close prematurely. This PR is to keep them active even if some bad data goes through. Added a bad metric to the udp test to make sure the listener stays open. It will bomb on master and works with the new functionality.

@jehiah this is ready for review. Thanks!