### PR TITLE
minor version bump for go1.5.1 binary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ Installing
 ### Binary Releases
 Pre-built binaries for darwin and linux.
 
-### Current Stable Release: `v0.7.1`
-* [statsdaemon-0.7.1.darwin-amd64.go1.4.2.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7.1/statsdaemon-0.7.1.darwin-amd64.go1.4.2.tar.gz)
-* [statsdaemon-0.7.1.linux-amd64.go1.4.2.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7.1/statsdaemon-0.7.1.linux-amd64.go1.4.2.tar.gz)
+### Current Stable Release: `v0.7.2`
+* [statsdaemon-0.7.2.darwin-amd64.go1.5.1.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7.2/statsdaemon-0.7.2.darwin-amd64.go1.5.1.tar.gz)
+* [statsdaemon-0.7.2.linux-amd64.go1.5.1.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7.2/statsdaemon-0.7.2.linux-amd64.go1.5.1.tar.gz)
 
 ### Older Releases
+* [statsdaemon-0.7.1.darwin-amd64.go1.4.2.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7.1/statsdaemon-0.7.1.darwin-amd64.go1.4.2.tar.gz)
+* [statsdaemon-0.7.1.linux-amd64.go1.4.2.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.7.1/statsdaemon-0.7.1.linux-amd64.go1.4.2.tar.gz)
 * [statsdaemon-0.6-alpha.darwin-amd64.go1.3.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.6-alpha/statsdaemon-0.6-alpha.darwin-amd64.go1.3.tar.gz)
 * [statsdaemon-0.6-alpha.linux-amd64.go1.3.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.6-alpha/statsdaemon-0.6-alpha.linux-amd64.go1.3.tar.gz)
 * [statsdaemon-0.5.2-alpha.linux-amd64.go1.1.1.tar.gz](https://github.com/bitly/statsdaemon/releases/download/v0.5.2-alpha/statsdaemon-0.5.2-alpha.linux-amd64.go1.1.1.tar.gz)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION = "0.7.1"
+const VERSION = "0.7.2"


### PR DESCRIPTION
This takes care of the docs/version.go, will upload the binaries as part of the release.