### PR TITLE
Update shell scripts to remove linuxism of /bin/bash and use /usr/bin…

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # build binary distributions for linux/amd64 and darwin/amd64
 set -e

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 go test -timeout 60s ./...


### PR DESCRIPTION
…/env bash which will work regardless of bash location


On various BSD's bash is not at /bin/bash it is at /usr/local/bin bash  this fixes building on FreeBSD