### PR TITLE
simpler delete-gauges handling

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -496,7 +496,7 @@ func parseLine(line []byte) *Packet {
 	case "c":
 		value, err = strconv.ParseFloat(string(val), 64)
 		if err != nil {
-			log.Printf("ERROR: failed to ParseInt %s - %s", string(val), err)
+			log.Printf("ERROR: failed to ParseFloat %s - %s", string(val), err)
 			return nil
 		}
 	case "g":
@@ -520,7 +520,7 @@ func parseLine(line []byte) *Packet {
 
 		value, err = strconv.ParseFloat(s, 64)
 		if err != nil {
-			log.Printf("ERROR: failed to ParseUint %s - %s", string(val), err)
+			log.Printf("ERROR: failed to ParseFloat %s - %s", string(val), err)
 			return nil
 		}
 

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -112,7 +112,6 @@ var (
 	In              = make(chan *Packet, MAX_UNPROCESSED_PACKETS)
 	counters        = make(map[string]float64)
 	gauges          = make(map[string]float64)
-	lastGaugeValue  = make(map[string]float64)
 	timers          = make(map[string]Float64Slice)
 	countInactivity = make(map[string]int64)
 	sets            = make(map[string][]string)
@@ -278,26 +277,11 @@ func processCounters(buffer *bytes.Buffer, now int64) int64 {
 func processGauges(buffer *bytes.Buffer, now int64) int64 {
 	var num int64
 
-	for bucket, gauge := range gauges {
-		currentValue := gauge
-		lastValue, hasLastValue := lastGaugeValue[bucket]
-		var hasChanged bool
-
-		if gauge != math.MaxFloat64 {
-			hasChanged = true
-		}
-
-		switch {
-		case hasChanged:
-			fmt.Fprintf(buffer, "%s %s %d\n", bucket, strconv.FormatFloat(currentValue, 'f', -1, 64), now)
-			lastGaugeValue[bucket] = currentValue
-			gauges[bucket] = math.MaxFloat64
-			num++
-		case hasLastValue && !hasChanged && !*deleteGauges:
-			fmt.Fprintf(buffer, "%s %s %d\n", bucket, strconv.FormatFloat(lastValue, 'f', -1, 64), now)
-			num++
-		default:
-			continue
+	for bucket, currentValue := range gauges {
+		fmt.Fprintf(buffer, "%s %s %d\n", bucket, strconv.FormatFloat(currentValue, 'f', -1, 64), now)
+		num++
+		if *deleteGauges {
+			delete(gauges, bucket)
 		}
 	}
 	return num

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -376,7 +376,7 @@ func TestPacketHandlerGauge(t *testing.T) {
 	packetHandler(p)
 	assert.Equal(t, gauges["gaugor"], float64(0))
 
-	// >2^64 overflow
+	// >MaxFloat64 overflow
 	p.Value = GaugeData{false, false, float64(math.MaxFloat64 - 10)}
 	packetHandler(p)
 	p.Value = GaugeData{true, false, 20}


### PR DESCRIPTION
More direct logic IMHO than using a sentinal value of MaxFloat64
and storing the last value for every gauge. Just a bool should do it.

Also, actually deletes gauges (if enabled), rather than keeping them
in the map and looping over them on every processGauges(),
indefinitely (until restart).

EDIT: updated with an even simpler scheme: just delete the gauges. I feel silly now ...

As an aside, I wonder if we want just this cleanup (continuing to match the deleteGauges option of etsy/statsd) and/or if we want gauges to have a "persist-gauge-keys" option (to match the "persist-count-keys" which statsdaemon already has), and/or if we want to add a "delete-counters" option (to match the deleteCounters option of etsy/statsd). Also, statsdaemon always deletes sets and timers, which is counter to the etsy/statsd defaults (which I think is OK).

Really, the lack of consistency between metric types is pretty funny. It's like they say about vim: it generally does what you want, unless what you want is consistency :smirk: 