### PR TITLE
minor scripts cleanups

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -1,26 +1,27 @@
-#!/usr/bin/env bash
-
+#!/bin/sh
 # build binary distributions for linux/amd64 and darwin/amd64
-set -e
+set -eu
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(dirname "$0")"
+DIR=$(pwd)
 echo "working dir $DIR"
 mkdir -p $DIR/dist
 
 arch=$(go env GOARCH)
-version=$(cat $DIR/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
+version=$(awk '/const VERSION/ {print $NF}' $DIR/version.go | sed 's/"//g')
 goversion=$(go version | awk '{print $3}')
 
 echo "... running tests"
-./test.sh || exit 1
+./test.sh
 
 for os in linux darwin freebsd; do
     echo "... building v$version for $os/$arch"
-    BUILD=$(mktemp -d -t statsdaemon.XXXXXXXX)
+    BUILD=$(mktemp -d ${TMPDIR:-/tmp}/statsdaemon.XXXXXX)
     TARGET="statsdaemon-$version.$os-$arch.$goversion"
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/statsdaemon || exit 1
-    pushd $BUILD
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o $BUILD/$TARGET/statsdaemon
+    cd $BUILD
     tar czvf $TARGET.tar.gz $TARGET
     mv $TARGET.tar.gz $DIR/dist
-    popd
+    cd $DIR
+    rm -r $BUILD
 done

--- a/dist.sh
+++ b/dist.sh
@@ -14,7 +14,7 @@ goversion=$(go version | awk '{print $3}')
 echo "... running tests"
 ./test.sh || exit 1
 
-for os in linux darwin; do
+for os in linux darwin freebsd; do
     echo "... building v$version for $os/$arch"
     BUILD=$(mktemp -d -t statsdaemon.XXXXXXXX)
     TARGET="statsdaemon-$version.$os-$arch.$goversion"

--- a/dist.sh
+++ b/dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # build binary distributions for linux/amd64 and darwin/amd64
 set -e

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 
 go test -timeout 60s ./...
 GOMAXPROCS=4 go test -timeout 60s -race ./...
-

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 go test -timeout 60s ./...


### PR DESCRIPTION
a follow-up to (and includes) #75 

  * use /bin/sh instead of bash
    * can't use `${BASH_SOURCE[0]}`, but that's only needed for *sourced* script files
    * can't use pushd/popd, but script depended on being executed from DIR already
  * make dist.sh really work when run from some other current working directory
  * make mktemp work the same on Linux and OS X
  * awk can do most of the VERSION parsing on its own
  * remove `|| exit 1` as `set -e` does that
  * add `set -u` to catch uninitialized variables

So, uh, not strictly needed :smile: 