### PR TITLE
Fix type assertion for counters in packetHandler func

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -185,7 +185,7 @@ func packetHandler(s *Packet) {
 		if !ok {
 			counters[s.Bucket] = 0
 		}
-		counters[s.Bucket] += float64(s.Value.(int64)) * float64(1/s.Sampling)
+		counters[s.Bucket] += s.Value.(float64) * float64(1/s.Sampling)
 	case "s":
 		_, ok := sets[s.Bucket]
 		if !ok {

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -311,7 +311,7 @@ func TestPacketHandlerReceiveCounter(t *testing.T) {
 
 	p := &Packet{
 		Bucket:   "gorets",
-		Value:    int64(100),
+		Value:    float64(100),
 		Modifier: "c",
 		Sampling: float32(1),
 	}
@@ -327,22 +327,22 @@ func TestPacketHandlerCount(t *testing.T) {
 
 	p := &Packet{
 		Bucket:   "gorets",
-		Value:    int64(100),
+		Value:    float64(100),
 		Modifier: "c",
 		Sampling: float32(1),
 	}
 	packetHandler(p)
 	assert.Equal(t, counters["gorets"], float64(100))
 
-	p.Value = int64(3)
+	p.Value = float64(3)
 	packetHandler(p)
 	assert.Equal(t, counters["gorets"], float64(103))
 
-	p.Value = int64(-4)
+	p.Value = float64(-4)
 	packetHandler(p)
 	assert.Equal(t, counters["gorets"], float64(99))
 
-	p.Value = int64(-100)
+	p.Value = float64(-100)
 	packetHandler(p)
 	assert.Equal(t, counters["gorets"], float64(-1))
 }


### PR DESCRIPTION
If the Packet type is a counter then the the value that gets parsed from the input is a float64 [here](https://github.com/stevefranks/statsdaemon/blob/master/statsdaemon.go#L497). This value is then passed to the packetHandler function [here] (https://github.com/stevefranks/statsdaemon/blob/master/statsdaemon.go#L141) (of which line 188 that that contains the change in question is a part of) through the Packet structure in a variable whose initial type is an interface [here] (https://github.com/stevefranks/statsdaemon/blob/master/statsdaemon.go#L31). When the value is accessed the type assertion **needs** to match the type of the value (which is a float) that is to be extracted from the interface or else the program will and does crash.

I have updated the tests and the program passes all of them.