### PR TITLE
Add Metric name to unrecognized type code error

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -515,7 +515,7 @@ func parseLine(line []byte) *Packet {
 			return nil
 		}
 	default:
-		log.Printf("ERROR: unrecognized type code %q for metric %s", typeCode, string(name))
+		log.Printf("ERROR: unrecognized type code %q for metric %s", typeCode, name)
 		return nil
 	}
 

--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -515,7 +515,7 @@ func parseLine(line []byte) *Packet {
 			return nil
 		}
 	default:
-		log.Printf("ERROR: unrecognized type code %q", typeCode)
+		log.Printf("ERROR: unrecognized type code %q for metric %s", typeCode, string(name))
 		return nil
 	}
 


### PR DESCRIPTION
Adding the metric name to the 'unrecognized type code' error makes it easier to debug the invalid metric in order to fix it.