### PR TITLE
updates tests to use a maintained assert package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 install:
-  - go get github.com/bmizerany/assert
+  - go get github.com/stretchr/testify
 script:
   - ./test.sh
 notifications:

--- a/statsdaemon_test.go
+++ b/statsdaemon_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 var commonPercentiles = Percentiles{


### PR DESCRIPTION
I noticed that the assert package we were using is no longer maintained. Made a change to use `stretchr/testify/assert` instead.