### PR TITLE
line reading slicing refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+go:
+  - 1.7.x
+  - 1.10.x
 sudo: false
 install:
   - go get github.com/stretchr/testify


### PR DESCRIPTION
avoid allocating in `MsgParser.Next()` and simplify a few other byte slice things

adds a few benchmarks, and here are the overall results:

```
$ benchcmp old.txt new.txt 
benchmark                           old ns/op      new ns/op      delta
BenchmarkManyDifferentSensors-4     1335610085     1330076467     -0.41%
BenchmarkOneBigTimer-4              1218612245     1228443022     +0.81%
BenchmarkLotsOfTimers-4             1334108023     1323987632     -0.76%
BenchmarkMsgParserUDP-4             1553           1089           -29.88%
BenchmarkMsgParserTCP-4             1164           983            -15.55%
BenchmarkParseLineCounter-4         903            794            -12.07%
BenchmarkParseLineGauge-4           859            774            -9.90%
BenchmarkParseLineTimer-4           878            755            -14.01%
BenchmarkParseLineSet-4             812            704            -13.30%
BenchmarkPacketHandlerCounter-4     79.2           78.1           -1.39%
BenchmarkPacketHandlerGauge-4       70.3           70.1           -0.28%
BenchmarkPacketHandlerTimer-4       107            107            +0.00%
BenchmarkPacketHandlerSet-4         120            118            -1.67%

benchmark                           old allocs     new allocs     delta
BenchmarkManyDifferentSensors-4     35059          35060          +0.00%
BenchmarkOneBigTimer-4              33             35             +6.06%
BenchmarkLotsOfTimers-4             25019          25017          -0.01%
BenchmarkMsgParserUDP-4             20             15             -25.00%
BenchmarkMsgParserTCP-4             18             14             -22.22%
BenchmarkParseLineCounter-4         17             13             -23.53%
BenchmarkParseLineGauge-4           17             13             -23.53%
BenchmarkParseLineTimer-4           16             12             -25.00%
BenchmarkParseLineSet-4             16             12             -25.00%
BenchmarkPacketHandlerCounter-4     0              0              +0.00%
BenchmarkPacketHandlerGauge-4       0              0              +0.00%
BenchmarkPacketHandlerTimer-4       0              0              +0.00%
BenchmarkPacketHandlerSet-4         0              0              +0.00%

benchmark                           old bytes     new bytes     delta
BenchmarkManyDifferentSensors-4     1556808       1556872       +0.00%
BenchmarkOneBigTimer-4              1784          1896          +6.28%
BenchmarkLotsOfTimers-4             840472        840360        -0.01%
BenchmarkMsgParserUDP-4             2260          596           -73.63%
BenchmarkMsgParserTCP-4             863           549           -36.38%
BenchmarkParseLineCounter-4         536           440           -17.91%
BenchmarkParseLineGauge-4           496           432           -12.90%
BenchmarkParseLineTimer-4           592           464           -21.62%
BenchmarkParseLineSet-4             588           460           -21.77%
BenchmarkPacketHandlerCounter-4     0             0             +0.00%
BenchmarkPacketHandlerGauge-4       0             0             +0.00%
BenchmarkPacketHandlerTimer-4       80            80            +0.00%
BenchmarkPacketHandlerSet-4         65            65            +0.00%
```

(some variability due to running these on a laptop, and no changes should have caused the OneBigTimer allocation differences ...)