### PR TITLE
Show only interval stats log during debug

### DIFF
--- a/statsdaemon.go
+++ b/statsdaemon.go
@@ -244,7 +244,9 @@ func submit(deadline time.Time) error {
 		return errors.New(errmsg)
 	}
 
-	log.Printf("sent %d stats to %s", num, *graphiteAddress)
+	if *debug {
+		log.Printf("sent %d stats to %s", num, *graphiteAddress)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Displaying this log generates a lot of noise in centralized logging when
using multiple instances of statsdaemon.

Also fits better to hide this in according with the -debug flag description.