### PR TITLE
publish-to-dockerhub: Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:latest as builder
+WORKDIR /statsdaemon/
+COPY . .
+RUN CGO_ENABLED=0 go build -o statsdaemon
+
+FROM alpine:latest
+COPY --from=builder /statsdaemon/statsdaemon /usr/local/bin/statsdaemon
+ENTRYPOINT ["statsdaemon"]


### PR DESCRIPTION
Adding Dockerfile to provide ability to run as a container workload.
